### PR TITLE
feat: Add Course management and missing admin templates

### DIFF
--- a/Booklet_Scan/app/admin/forms.py
+++ b/Booklet_Scan/app/admin/forms.py
@@ -1,14 +1,32 @@
 from flask_wtf import FlaskForm
 from wtforms import StringField, SubmitField, IntegerField, DateField, TimeField, SelectField
-from wtforms.validators import DataRequired, Optional, ValidationError
-from app.models import Venue # For Venue selection in ExamForm
+from wtforms.validators import DataRequired, Optional, ValidationError, Length
+from app.models import Venue, Course # For Venue selection in ExamForm and Course model
+
+# Form for Course
+class CourseForm(FlaskForm):
+    name = StringField('Course Name', validators=[DataRequired(), Length(max=128)])
+    code = StringField('Course Code (Optional)', validators=[Optional(), Length(max=20)])
+    submit = SubmitField('Save Course')
 
 # Form for Student
 class StudentForm(FlaskForm):
     name = StringField('Full Name', validators=[DataRequired()])
     student_id = StringField('Student ID', validators=[DataRequired()])
-    course = StringField('Course', validators=[DataRequired()])
+    # Course will be a SelectField, populated in routes
+    course = SelectField('Course', validators=[DataRequired(message="Please select a course.")])
     submit = SubmitField('Save Student')
+
+    def __init__(self, *args, **kwargs):
+        super(StudentForm, self).__init__(*args, **kwargs)
+        # Populate course choices dynamically. This will be overridden in the route
+        # to ensure fresh data, but good to have a default.
+        self.course.choices = [(c.name, c.name) for c in Course.query.order_by(Course.name).all()]
+        if not self.course.choices:
+            self.course.choices.insert(0, ('', 'No courses available - Add courses first'))
+        # else: # No need for "Select a course" here if DataRequired and no default choice value
+            # self.course.choices.insert(0, ('', '--- Select a Course ---'))
+
 
 # Form for Venue
 class VenueForm(FlaskForm):

--- a/Booklet_Scan/app/main/forms.py
+++ b/Booklet_Scan/app/main/forms.py
@@ -12,11 +12,13 @@ class ScanForm(FlaskForm):
     def __init__(self, *args, **kwargs):
         super(ScanForm, self).__init__(*args, **kwargs)
         # Populate exam choices dynamically
+        # Populate exam choices dynamically
+        # No explicit placeholder with ('', 'Text') is added here.
+        # The browser will default to the first actual option or show nothing if the list is empty.
+        # DataRequired validator will ensure an actual exam is selected on submit.
         self.exam_id.choices = [
             (e.id, f"{e.name} - {e.course} (on {e.date.strftime('%Y-%m-%d')} at {e.venue.name if e.venue else 'N/A'})")
             for e in Exam.query.join(Venue).order_by(Exam.date.desc(), Exam.name).all()
         ]
-        if not self.exam_id.choices:
-            self.exam_id.choices.insert(0, ('', 'No exams available - Please add exams in Admin Panel'))
-        else:
-            self.exam_id.choices.insert(0, ('', '--- Select an Exam ---'))
+        # An empty list of choices is fine; DataRequired will handle validation.
+        # The route will flash a message if no exams are available.

--- a/Booklet_Scan/app/main/routes.py
+++ b/Booklet_Scan/app/main/routes.py
@@ -21,9 +21,17 @@ def index():
 def scan_ui():
     form = ScanForm()
 
+    # Check if exams are available and flash a message if not
+    if not form.exam_id.choices:
+        flash("No exams are currently available for scanning. Please add exams via the admin panel.", "warning")
+
     # Keep selected exam_id if form is re-rendered due to error or successful scan
     if request.method == 'GET' and request.args.get('last_exam_id'):
-        form.exam_id.data = int(request.args.get('last_exam_id'))
+        try:
+            # Ensure last_exam_id is a valid integer before assigning
+            form.exam_id.data = int(request.args.get('last_exam_id'))
+        except (ValueError, TypeError):
+            pass # Ignore if last_exam_id is not a valid int
 
     if form.validate_on_submit():
         exam_id = form.exam_id.data

--- a/Booklet_Scan/app/models.py
+++ b/Booklet_Scan/app/models.py
@@ -33,6 +33,14 @@ class Student(db.Model):
     def __repr__(self):
         return f'<Student {self.student_id} - {self.name}>'
 
+class Course(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    name = db.Column(db.String(128), unique=True, nullable=False)
+    code = db.Column(db.String(20), unique=True, nullable=True) # E.g., CS101
+
+    def __repr__(self):
+        return f'<Course {self.name}{(" (" + self.code + ")") if self.code else ""}>'
+
 class Venue(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     name = db.Column(db.String(128), unique=True, nullable=False)

--- a/Booklet_Scan/app/templates/admin/assignment_form.html
+++ b/Booklet_Scan/app/templates/admin/assignment_form.html
@@ -1,0 +1,33 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h3 class="mb-0">{{ title }}</h3>
+                </div>
+                <div class="card-body">
+                    {% if not form.student_id.choices or not form.exam_id.choices %}
+                        <div class="alert alert-warning">
+                            {% if not form.student_id.choices %}
+                                <p class="mb-1">No students available. Please <a href="{{ url_for('admin.add_student') }}" class="alert-link">add students</a> first.</p>
+                            {% endif %}
+                            {% if not form.exam_id.choices %}
+                                <p class="mb-0">No exams available. Please <a href="{{ url_for('admin.add_exam') }}" class="alert-link">add exams</a> first.</p>
+                            {% endif %}
+                        </div>
+                    {% else %}
+                        {{ wtf.quick_form(form, button_map={'submit': 'btn btn-primary btn-lg shadow-sm'}) }}
+                    {% endif %}
+                </div>
+                <div class="card-footer bg-light text-right">
+                     <a href="{{ url_for('admin.list_assignments') }}" class="btn btn-outline-secondary shadow-sm">Cancel</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/assignments_list.html
+++ b/Booklet_Scan/app/templates/admin/assignments_list.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row mb-3">
+        <div class="col-md-9">
+            <h1 class="display-5">Manage Student Assignments</h1>
+            <p class="text-muted">Assign students to exams or remove existing assignments.</p>
+        </div>
+        <div class="col-md-3 text-right">
+            <a href="{{ url_for('admin.add_assignment') }}" class="btn btn-success shadow-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3v-3z"/>
+                </svg>
+                New Assignment
+            </a>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            {% if assignments.items %}
+            <table class="table table-hover table-responsive-md">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Student Name</th>
+                        <th>Student ID</th>
+                        <th>Exam Name</th>
+                        <th>Exam Date</th>
+                        <th>Venue</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for assignment in assignments.items %}
+                    <tr>
+                        <td>{{ assignment.student.name if assignment.student else 'N/A' }}</td>
+                        <td>{{ assignment.student.student_id if assignment.student else 'N/A' }}</td>
+                        <td>{{ assignment.exam.name if assignment.exam else 'N/A' }}</td>
+                        <td>{{ assignment.exam.date.strftime('%Y-%m-%d') if assignment.exam and assignment.exam.date else 'N/A' }}</td>
+                        <td>{{ assignment.exam.venue.name if assignment.exam and assignment.exam.venue else 'N/A' }}</td>
+                        <td class="text-center">
+                            <form action="{{ url_for('admin.delete_assignment', id=assignment.id) }}" method="post" style="display:inline;">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete this assignment for student {{ assignment.student.name if assignment.student else 'N/A' }} to exam {{ assignment.exam.name if assignment.exam else 'N/A' }}?');">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1H2.5zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5zM8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5zm3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0z"/>
+                                    </svg> Delete
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="alert alert-info" role="alert">
+                No student assignments found. You can <a href="{{ url_for('admin.add_assignment') }}" class="alert-link">add a new assignment</a>.
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if assignments.pages > 1 %}
+    <div class="mt-3">
+        {% include 'admin/_pagination.html' with context %} {# Ensure 'assignments' is passed as 'pagination' in context #}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/course_form.html
+++ b/Booklet_Scan/app/templates/admin/course_form.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h3 class="mb-0">{{ title }}</h3>
+                </div>
+                <div class="card-body">
+                    {{ wtf.quick_form(form, button_map={'submit': 'btn btn-primary btn-lg shadow-sm'}) }}
+                </div>
+                <div class="card-footer bg-light text-right">
+                     <a href="{{ url_for('admin.list_courses') }}" class="btn btn-outline-secondary shadow-sm">Cancel</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/courses_list.html
+++ b/Booklet_Scan/app/templates/admin/courses_list.html
@@ -1,0 +1,70 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row mb-3">
+        <div class="col-md-9">
+            <h1 class="display-5">Manage Courses</h1>
+            <p class="text-muted">View, add, edit, or delete course records.</p>
+        </div>
+        <div class="col-md-3 text-right">
+            <a href="{{ url_for('admin.add_course') }}" class="btn btn-success shadow-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3v-3z"/>
+                </svg>
+                Add New Course
+            </a>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            {% if courses.items %}
+            <table class="table table-hover table-responsive-md">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Course Name</th>
+                        <th>Course Code</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for course_item in courses.items %} {# Renamed course to course_item to avoid conflict with student.course #}
+                    <tr>
+                        <td>{{ course_item.name }}</td>
+                        <td>{{ course_item.code if course_item.code else 'N/A' }}</td>
+                        <td class="text-center">
+                            <a href="{{ url_for('admin.edit_course', id=course_item.id) }}" class="btn btn-sm btn-outline-primary mr-1">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                                    <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.636a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
+                                    <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
+                                </svg> Edit
+                            </a>
+                            <form action="{{ url_for('admin.delete_course', id=course_item.id) }}" method="post" style="display:inline;">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete course: {{ course_item.name }}? This action cannot be undone.');">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1H2.5zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5zM8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5zm3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0z"/>
+                                    </svg> Delete
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="alert alert-info" role="alert">
+                No courses found. You can <a href="{{ url_for('admin.add_course') }}" class="alert-link">add a new course</a>.
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if courses.pages > 1 %}
+    <div class="mt-3">
+        {% include 'admin/_pagination.html' with context %} {# Ensure 'courses' is passed as 'pagination' in context or adapt macro #}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/dashboard.html
+++ b/Booklet_Scan/app/templates/admin/dashboard.html
@@ -49,10 +49,19 @@
                 </div>
             </div>
         </div>
+        <div class="col-md-6 mb-3">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <h5 class="card-title">Courses</h5>
+                    <p class="card-text">Define and manage academic courses.</p>
+                    <a href="{{ url_for('admin.list_courses') }}" class="btn btn-outline-primary">Manage Courses</a>
+                </div>
+            </div>
+        </div>
     </div>
-     <div class="row">
+     <div class="row mt-3"> {# Added mt-3 for spacing #}
         <div class="col-md-12 mb-3 text-center">
-            <hr>
+            <hr class="my-4"> {# Enhanced hr #}
             <a href="{{ url_for('main.scan_ui') }}" class="btn btn-lg btn-success shadow">
                 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" fill="currentColor" class="bi bi-upc-scan" viewBox="0 0 16 16">
                     <path d="M1.5 1a.5.5 0 0 0-.5.5v3a.5.5 0 0 1-1 0v-3A1.5 1.5 0 0 1 1.5 0h3a.5.5 0 0 1 0 1h-3zM11 .5a.5.5 0 0 1 .5-.5h3A1.5 1.5 0 0 1 16 1.5v3a.5.5 0 0 1-1 0v-3a.5.5 0 0 0-.5-.5h-3a.5.5 0 0 1-.5-.5zM.5 11a.5.5 0 0 1 .5.5v3a.5.5 0 0 0 .5.5h3a.5.5 0 0 1 0 1h-3A1.5 1.5 0 0 1 0 14.5v-3a.5.5 0 0 1 .5-.5zm15 0a.5.5 0 0 1 .5.5v3a1.5 1.5 0 0 1-1.5 1.5h-3a.5.5 0 0 1 0-1h3a.5.5 0 0 0 .5-.5v-3a.5.5 0 0 1 .5-.5zM3 4.5a.5.5 0 0 1 1 0v7a.5.5 0 0 1-1 0v-7zm2 0a.5.5 0 0 1 1 0v7a.5.5 0 0 1-1 0v-7zm2 0a.5.5 0 0 1 1 0v7a.5.5 0 0 1-1 0v-7zm2 0a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-7zm3 0a.5.5 0 0 1 1 0v7a.5.5 0 0 1-1 0v-7z"/>

--- a/Booklet_Scan/app/templates/admin/exam_form.html
+++ b/Booklet_Scan/app/templates/admin/exam_form.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h3 class="mb-0">{{ title }}</h3>
+                </div>
+                <div class="card-body">
+                    {{ wtf.quick_form(form, button_map={'submit': 'btn btn-primary btn-lg shadow-sm'}) }}
+                </div>
+                <div class="card-footer bg-light text-right">
+                     <a href="{{ url_for('admin.list_exams') }}" class="btn btn-outline-secondary shadow-sm">Cancel</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/exams_list.html
+++ b/Booklet_Scan/app/templates/admin/exams_list.html
@@ -1,0 +1,78 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row mb-3">
+        <div class="col-md-9">
+            <h1 class="display-5">Manage Exams</h1>
+            <p class="text-muted">View, add, edit, or delete exam records.</p>
+        </div>
+        <div class="col-md-3 text-right">
+            <a href="{{ url_for('admin.add_exam') }}" class="btn btn-success shadow-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3v-3z"/>
+                </svg>
+                Add New Exam
+            </a>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            {% if exams.items %}
+            <table class="table table-hover table-responsive-md">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Name</th>
+                        <th>Course</th>
+                        <th>Venue</th>
+                        <th>Date</th>
+                        <th>Start Time</th>
+                        <th>End Time</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for exam in exams.items %}
+                    <tr>
+                        <td>{{ exam.name }}</td>
+                        <td>{{ exam.course }}</td>
+                        <td>{{ exam.venue.name if exam.venue else 'N/A' }}</td>
+                        <td>{{ exam.date.strftime('%Y-%m-%d') if exam.date else 'N/A' }}</td>
+                        <td>{{ exam.start_time.strftime('%H:%M') if exam.start_time else 'N/A' }}</td>
+                        <td>{{ exam.end_time.strftime('%H:%M') if exam.end_time else 'N/A' }}</td>
+                        <td class="text-center">
+                            <a href="{{ url_for('admin.edit_exam', id=exam.id) }}" class="btn btn-sm btn-outline-primary mr-1">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                                    <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.636a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
+                                    <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
+                                </svg> Edit
+                            </a>
+                            <form action="{{ url_for('admin.delete_exam', id=exam.id) }}" method="post" style="display:inline;">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete exam: {{ exam.name }}? This action cannot be undone.');">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1H2.5zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5zM8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5zm3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0z"/>
+                                    </svg> Delete
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="alert alert-info" role="alert">
+                No exams found. You can <a href="{{ url_for('admin.add_exam') }}" class="alert-link">add a new exam</a>.
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if exams.pages > 1 %}
+    <div class="mt-3">
+        {% include 'admin/_pagination.html' with context %} {# Ensure 'exams' is passed as 'pagination' in context #}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/venue_form.html
+++ b/Booklet_Scan/app/templates/admin/venue_form.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row">
+        <div class="col-md-8 offset-md-2">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h3 class="mb-0">{{ title }}</h3>
+                </div>
+                <div class="card-body">
+                    {{ wtf.quick_form(form, button_map={'submit': 'btn btn-primary btn-lg shadow-sm'}) }}
+                </div>
+                <div class="card-footer bg-light text-right">
+                     <a href="{{ url_for('admin.list_venues') }}" class="btn btn-outline-secondary shadow-sm">Cancel</a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/admin/venues_list.html
+++ b/Booklet_Scan/app/templates/admin/venues_list.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% import "bootstrap/wtf.html" as wtf %}
+
+{% block app_content %}
+<div class="container mt-4">
+    <div class="row mb-3">
+        <div class="col-md-9">
+            <h1 class="display-5">Manage Venues</h1>
+            <p class="text-muted">View, add, edit, or delete examination venue records.</p>
+        </div>
+        <div class="col-md-3 text-right">
+            <a href="{{ url_for('admin.add_venue') }}" class="btn btn-success shadow-sm">
+                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-plus-circle-fill" viewBox="0 0 16 16">
+                    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM8.5 4.5a.5.5 0 0 0-1 0v3h-3a.5.5 0 0 0 0 1h3v3a.5.5 0 0 0 1 0v-3h3a.5.5 0 0 0 0-1h-3v-3z"/>
+                </svg>
+                Add New Venue
+            </a>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            {% if venues.items %}
+            <table class="table table-hover table-responsive-md">
+                <thead class="thead-light">
+                    <tr>
+                        <th>Name</th>
+                        <th>Location</th>
+                        <th>Capacity</th>
+                        <th class="text-center">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for venue in venues.items %}
+                    <tr>
+                        <td>{{ venue.name }}</td>
+                        <td>{{ venue.location if venue.location else 'N/A' }}</td>
+                        <td>{{ venue.capacity if venue.capacity is not none else 'N/A' }}</td>
+                        <td class="text-center">
+                            <a href="{{ url_for('admin.edit_venue', id=venue.id) }}" class="btn btn-sm btn-outline-primary mr-1">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-pencil-square" viewBox="0 0 16 16">
+                                    <path d="M15.502 1.94a.5.5 0 0 1 0 .706L14.459 3.69l-2-2L13.502.636a.5.5 0 0 1 .707 0l1.293 1.293zm-1.75 2.456-2-2L4.939 9.21a.5.5 0 0 0-.121.196l-.805 2.414a.25.25 0 0 0 .316.316l2.414-.805a.5.5 0 0 0 .196-.12l6.813-6.814z"/>
+                                    <path fill-rule="evenodd" d="M1 13.5A1.5 1.5 0 0 0 2.5 15h11a1.5 1.5 0 0 0 1.5-1.5v-6a.5.5 0 0 0-1 0v6a.5.5 0 0 1-.5.5h-11a.5.5 0 0 1-.5-.5v-11a.5.5 0 0 1 .5-.5H9a.5.5 0 0 0 0-1H2.5A1.5 1.5 0 0 0 1 2.5v11z"/>
+                                </svg> Edit
+                            </a>
+                            <form action="{{ url_for('admin.delete_venue', id=venue.id) }}" method="post" style="display:inline;">
+                                <button type="submit" class="btn btn-sm btn-outline-danger" onclick="return confirm('Are you sure you want to delete venue: {{ venue.name }}? This action cannot be undone.');">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-trash-fill" viewBox="0 0 16 16">
+                                        <path d="M2.5 1a1 1 0 0 0-1 1v1a1 1 0 0 0 1 1H3v9a2 2 0 0 0 2 2h6a2 2 0 0 0 2-2V4h.5a1 1 0 0 0 1-1V2a1 1 0 0 0-1-1H10a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1H2.5zm3 4a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5zM8 5a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7A.5.5 0 0 1 8 5zm3 .5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 1 0z"/>
+                                    </svg> Delete
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {% else %}
+            <div class="alert alert-info" role="alert">
+                No venues found. You can <a href="{{ url_for('admin.add_venue') }}" class="alert-link">add a new venue</a>.
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    {% if venues.pages > 1 %}
+    <div class="mt-3">
+        {% include 'admin/_pagination.html' with context %} {# Ensure 'venues' is passed as 'pagination' in context #}
+    </div>
+    {% endif %}
+</div>
+{% endblock %}

--- a/Booklet_Scan/app/templates/main/scan_interface.html
+++ b/Booklet_Scan/app/templates/main/scan_interface.html
@@ -14,48 +14,53 @@
                     <form method="POST" action="{{ url_for('main.scan_ui') }}" id="scanForm">
                         {{ form.hidden_tag() }} {# CSRF token #}
 
-                        <div class="form-group row mb-3">
-                            <label for="exam_id" class="col-sm-3 col-form-label text-right">Select Exam:</label>
-                            <div class="col-sm-9">
-                                {{ form.exam_id(class="form-control" + (" is-invalid" if form.exam_id.errors else "")) }}
-                                {% if form.exam_id.errors %}
-                                    <div class="invalid-feedback">
-                                        {% for error in form.exam_id.errors %}<span>{{ error }}</span>{% endfor %}
-                                    </div>
-                                {% endif %}
+                        {% if form.exam_id.choices %}
+                            <div class="form-group row mb-3">
+                                <label for="exam_id" class="col-sm-3 col-form-label text-right">Select Exam:</label>
+                                <div class="col-sm-9">
+                                    {{ form.exam_id(class="form-control" + (" is-invalid" if form.exam_id.errors else "")) }}
+                                    {% if form.exam_id.errors %}
+                                        <div class="invalid-feedback">
+                                            {% for error in form.exam_id.errors %}<span>{{ error }}</span>{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="form-group row mb-3">
-                            <label for="booklet_code" class="col-sm-3 col-form-label text-right">Booklet Code:</label>
-                            <div class="col-sm-9">
-                                {{ form.booklet_code(class="form-control" + (" is-invalid" if form.booklet_code.errors else ""), autofocus=true, placeholder="Scan or type booklet code") }}
-                                {% if form.booklet_code.errors %}
-                                    <div class="invalid-feedback">
-                                        {% for error in form.booklet_code.errors %}<span>{{ error }}</span>{% endfor %}
-                                    </div>
-                                {% endif %}
+                            <div class="form-group row mb-3">
+                                <label for="booklet_code" class="col-sm-3 col-form-label text-right">Booklet Code:</label>
+                                <div class="col-sm-9">
+                                    {{ form.booklet_code(class="form-control" + (" is-invalid" if form.booklet_code.errors else ""), autofocus=true, placeholder="Scan or type booklet code") }}
+                                    {% if form.booklet_code.errors %}
+                                        <div class="invalid-feedback">
+                                            {% for error in form.booklet_code.errors %}<span>{{ error }}</span>{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
-                        </div>
 
-                        {# This field will be populated by JavaScript after a successful scan or if a student needs to be manually entered/confirmed #}
-                        <div class="form-group row mb-3">
-                            <label for="student_identifier" class="col-sm-3 col-form-label text-right">Student ID:</label>
-                            <div class="col-sm-9">
-                                {{ form.student_identifier(class="form-control" + (" is-invalid" if form.student_identifier.errors else ""), placeholder="Student ID (e.g., from booklet or manual entry)") }}
-                                {% if form.student_identifier.errors %}
-                                    <div class="invalid-feedback">
-                                        {% for error in form.student_identifier.errors %}<span>{{ error }}</span>{% endfor %}
-                                    </div>
-                                {% endif %}
+                            <div class="form-group row mb-3">
+                                <label for="student_identifier" class="col-sm-3 col-form-label text-right">Student ID:</label>
+                                <div class="col-sm-9">
+                                    {{ form.student_identifier(class="form-control" + (" is-invalid" if form.student_identifier.errors else ""), placeholder="Student ID (e.g., from booklet or manual entry)") }}
+                                    {% if form.student_identifier.errors %}
+                                        <div class="invalid-feedback">
+                                            {% for error in form.student_identifier.errors %}<span>{{ error }}</span>{% endfor %}
+                                        </div>
+                                    {% endif %}
+                                </div>
                             </div>
-                        </div>
 
-                        <div class="form-group row">
-                            <div class="col-sm-9 offset-sm-3">
-                                {{ form.submit(class="btn btn-primary btn-block") }}
+                            <div class="form-group row">
+                                <div class="col-sm-9 offset-sm-3">
+                                    {{ form.submit(class="btn btn-primary btn-block") }}
+                                </div>
                             </div>
-                        </div>
+                        {% else %}
+                            {# This message is shown if there are no exams to select. #}
+                            {# Flashed message from the route will also appear. #}
+                            <p class="text-center text-muted">No exams available for scanning. Please add exams in the admin panel.</p>
+                        {% endif %}
                     </form>
                 </div>
             </div>


### PR DESCRIPTION
- Added a new `Course` model for managing courses.
- Implemented CRUD functionality for Courses in the admin panel, including routes, forms, and templates (`courses_list.html`, `course_form.html`).
- Updated the admin dashboard to include a link to Manage Courses.
- Modified the Student registration form (`StudentForm`) to use a `SelectField` for courses, populated dynamically from the `Course` table.
  - Student and Exam models still store `course` as a string for now to avoid complex migrations immediately.
- Created all previously missing admin templates to resolve `TemplateNotFound` errors:
  - `venues_list.html` and `venue_form.html`
  - `exams_list.html` and `exam_form.html`
  - `assignments_list.html` and `assignment_form.html`
- These new templates are styled consistently with the existing admin pages.

Note: To use the new Course functionality, the database needs to be updated to include the 'course' table. If using SQLite and it's safe to reset development data, delete `app.db` and let `db.create_all()` (implicitly run by Flask or explicitly in `flask shell`) recreate it. Otherwise, manual schema addition for the `course` table is needed if preserving data.