### PR TITLE
fix: Correct global scope for lcd_active in lcd_display utility

### DIFF
--- a/Booklet_Scan/app/utils/lcd_display.py
+++ b/Booklet_Scan/app/utils/lcd_display.py
@@ -54,6 +54,7 @@ def display_message(line1, line2="", clear_first=True, delay_after=None):
     Clears the display first by default.
     Optionally waits for 'delay_after' seconds.
     """
+    global lcd_active # Moved to the top of the function
     if not lcd_active:
         if lcd is None: # Attempt to initialize if not tried before or failed
             print("LCD not active. Attempting to initialize...")
@@ -89,6 +90,7 @@ def display_message(line1, line2="", clear_first=True, delay_after=None):
 
 def clear_display():
     """Clears the LCD display."""
+    global lcd_active # Moved to the top of the function
     if not lcd_active or lcd is None:
         print("Console LCD: Cleared")
         return


### PR DESCRIPTION
Moved `global lcd_active` to the beginning of the `display_message` and `clear_display` functions in `app/utils/lcd_display.py`. This resolves the `SyntaxError: name 'lcd_active' is used prior to global declaration` that occurred because the global variable was read before its global declaration within the function scope where an assignment also occurred.