### PR TITLE
fix: Resolve AttributeError for lcd_active in LCD utility

### DIFF
--- a/Booklet_Scan/app/main/routes.py
+++ b/Booklet_Scan/app/main/routes.py
@@ -25,7 +25,7 @@ def scan_ui():
     verified_student_info = request.args.get('student_info', None) # JSON string or similar
 
     # Initialize LCD if not already active
-    if not lcd_display.lcd_active:
+    if not lcd_display.is_lcd_active(): # Use the new getter function
         lcd_display.init_lcd()
 
     if not form.exam_id.choices:

--- a/Booklet_Scan/app/utils/lcd_display.py
+++ b/Booklet_Scan/app/utils/lcd_display.py
@@ -23,7 +23,11 @@ LCD_COLS = 16 # Common LCD column count (e.g., 16x2 or 20x4)
 LCD_ROWS = 2  # Common LCD row count
 
 lcd = None
-lcd_active = False
+lcd_active = False # Ensure this is defined at module level
+
+def is_lcd_active():
+    """Returns the current status of lcd_active."""
+    return lcd_active
 
 def init_lcd(i2c_address=DEFAULT_I2C_ADDRESS, i2c_bus=DEFAULT_I2C_BUS, cols=LCD_COLS, rows=LCD_ROWS):
     """


### PR DESCRIPTION
- Added a getter function `is_lcd_active()` to `app/utils/lcd_display.py` that returns the module-level `lcd_active` variable.
- Updated `app/main/routes.py` to use `lcd_display.is_lcd_active()` instead of directly accessing `lcd_display.lcd_active`.

This change ensures that the status of the LCD (`lcd_active`) is accessed via a defined function, resolving the `AttributeError` and allowing the application to correctly check if the LCD is active before attempting to use it.