### PR TITLE
Implement headless Raspberry Pi scanning via direct input

### DIFF
--- a/Booklet_Scan/app/templates/main/scan_interface.html
+++ b/Booklet_Scan/app/templates/main/scan_interface.html
@@ -1,181 +1,92 @@
 {% extends "base.html" %}
-{% import "bootstrap/wtf.html" as wtf %}
 
 {% block app_content %}
-<div class="container mt-4">
-    <h1>Booklet Scanning - Two Step</h1>
-    <div class="row">
-        <div class="col-md-8 offset-md-2">
-
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    <div class="mt-3">
-                        {% for category, message in messages %}
+<div class="container mt-5">
+    <div class="row justify-content-center">
+        <div class="col-md-8">
+            <div class="card shadow-sm">
+                <div class="card-header bg-primary text-white">
+                    <h3 class="mb-0">Scanning System Status</h3>
+                </div>
+                <div class="card-body" style="min-height: 250px;">
+                    {% with messages = get_flashed_messages(with_categories=true) %}
+                        {% if messages %}
+                            {% for category, message in messages %}
                             <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
                                 {{ message }}
                                 <button type="button" class="close" data-dismiss="alert" aria-label="Close">
                                     <span aria-hidden="true">&times;</span>
                                 </button>
                             </div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            {% endwith %}
+                            {% endfor %}
+                        {% endif %}
+                    {% endwith %}
 
-            <div class="card mt-3">
-                <div class="card-header">
-                    {% if scan_step == 'scan_booklet' and student_info %}
-                        Step 2: Scan Booklet for {{ student_info.name }} ({{ student_info.student_id }}) - Exam: {{ student_info.exam_name }}
-                    {% else %}
-                        Step 1: Find Student & Check Eligibility
-                    {% endif %}
-                </div>
-                <div class="card-body">
-                    <form method="POST" action="{{ url_for('main.scan_ui', scan_step=scan_step, student_info=student_info | tojson if student_info else None) }}" id="scanForm">
-                        {{ form.hidden_tag() }} {# CSRF token #}
+                    {% if active_exam_name and active_exam_name != 'N/A' and expected_input != 'none' %}
+                        <h4 class="card-title">Scan Mode Active</h4>
+                        <p class="lead"><strong>Current Exam:</strong> {{ active_exam_name }}</p>
 
-                        {# Always show exam selection, potentially readonly in step 2 #}
-                        <div class="form-group row mb-3">
-                            <label for="exam_id" class="col-sm-3 col-form-label text-right">Select Exam:</label>
-                            <div class="col-sm-9">
-                                {% if scan_step == 'scan_booklet' and student_info %}
-                                    <input type="text" readonly class="form-control-plaintext" value="{{ student_info.exam_name }}">
-                                    {{ form.exam_id(class="form-control d-none", value=student_info.exam_id) }} {# Hidden but submitted #}
-                                {% else %}
-                                    {{ form.exam_id(class="form-control" + (" is-invalid" if form.exam_id.errors else "")) }}
-                                {% endif %}
-                                {% if form.exam_id.errors and not (scan_step == 'scan_booklet' and student_info) %}
-                                    <div class="invalid-feedback">
-                                        {% for error in form.exam_id.errors %}<span>{{ error }}</span>{% endfor %}
-                                    </div>
-                                {% endif %}
+                        {% if expected_input == 'student' %}
+                            <div class="alert alert-info" role="alert">
+                                <h5 class="alert-heading">Status: Waiting for Student ID Scan</h5>
+                                <p>The system is ready to process the next <strong>Student ID</strong> scan from the Raspberry Pi.</p>
+                                <hr>
+                                <p class="mb-0">The I2C LCD on the Raspberry Pi should also indicate this status.</p>
                             </div>
-                        </div>
-
-                        {# Student Identifier Field - visible in step 1, readonly/hidden in step 2 #}
-                        <div class="form-group row mb-3">
-                            <label for="student_identifier" class="col-sm-3 col-form-label text-right">Student ID:</label>
-                            <div class="col-sm-9">
-                                {% if scan_step == 'scan_booklet' and student_info %}
-                                    <input type="text" readonly class="form-control-plaintext" value="{{ student_info.student_id }}">
-                                    {{ form.student_identifier(class="form-control d-none", value=student_info.student_id) }} {# Hidden but submitted #}
+                        {% elif expected_input == 'booklet' %}
+                            <div class="alert alert-success" role="alert">
+                                <h5 class="alert-heading">Status: Waiting for Booklet Code Scan</h5>
+                                {% if verified_student_name %}
+                                <p>Student <strong>{{ verified_student_name }}</strong> has been verified.</p>
                                 {% else %}
-                                    {{ form.student_identifier(class="form-control" + (" is-invalid" if form.student_identifier.errors else ""), autofocus=true, placeholder="Scan or type Student ID") }}
+                                <p>A student has been verified.</p>
                                 {% endif %}
-                                {% if form.student_identifier.errors and not (scan_step == 'scan_booklet' and student_info) %}
-                                    <div class="invalid-feedback">
-                                        {% for error in form.student_identifier.errors %}<span>{{ error }}</span>{% endfor %}
-                                    </div>
-                                {% endif %}
+                                <p>The system is ready to process the <strong>Booklet Code</strong> scan for this student from the Raspberry Pi.</p>
+                                <hr>
+                                <p class="mb-0">The I2C LCD on the Raspberry Pi should also indicate this status.</p>
                             </div>
-                        </div>
-
-                        {# Booklet Code Field - visible only in step 2 #}
-                        {% if scan_step == 'scan_booklet' and student_info %}
-                            <div class="form-group row mb-3">
-                                <label for="booklet_code" class="col-sm-3 col-form-label text-right">Booklet Code:</label>
-                                <div class="col-sm-9">
-                                    {{ form.booklet_code(class="form-control" + (" is-invalid" if form.booklet_code.errors else ""), autofocus=true, placeholder="Scan or type Booklet Code") }}
-                                    {% if form.booklet_code.errors %}
-                                        <div class="invalid-feedback">
-                                            {% for error in form.booklet_code.errors %}<span>{{ error }}</span>{% endfor %}
-                                        </div>
-                                    {% endif %}
-                                </div>
+                        {% else %}
+                             <div class="alert alert-secondary" role="alert">
+                                <h5 class="alert-heading">Status: Idle</h5>
+                                <p>The system is idle. An unknown state for 'expected_input' ({{ expected_input }}).</p>
                             </div>
                         {% endif %}
-
-                        {# Submit Buttons - visibility depends on step #}
-                        <div class="form-group row">
-                            <div class="col-sm-9 offset-sm-3">
-                                {% if scan_step == 'scan_booklet' and student_info %}
-                                    {{ form.submit_record_scan(class="btn btn-success btn-block shadow-sm") }}
-                                    <a href="{{ url_for('main.scan_ui') }}" class="btn btn-outline-secondary btn-block mt-2">Cancel / Next Student</a>
-                                {% else %}
-                                    {% if form.exam_id.choices %}
-                                        {{ form.submit_check_student(class="btn btn-primary btn-block shadow-sm") }}
-                                    {% else %}
-                                        <p class="text-center text-muted">No exams available for scanning. Please add exams in the admin panel.</p>
-                                    {% endif %}
-                                {% endif %}
-                            </div>
+                    {% else %}
+                        <div class="alert alert-warning" role="alert">
+                            <h4 class="alert-heading">Scanning System Idle</h4>
+                            <p>No exam is currently active for scanning.</p>
+                            <hr>
+                            <p class="mb-0">Please go to the <a href="{{ url_for('admin.list_exams') }}" class="alert-link">Manage Exams</a> page in the admin dashboard to start authentication for an exam. The I2C LCD should be displaying the Raspberry Pi's IP address.</p>
                         </div>
-                    </form>
+                    {% endif %}
+
+                    <div class="mt-4 text-center">
+                        <a href="{{ url_for('main.scan_ui') }}" class="btn btn-outline-secondary btn-sm">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-arrow-clockwise" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd" d="M8 3a5 5 0 1 0 4.546 2.914.5.5 0 0 1 .908-.417A6 6 0 1 1 8 2v1z"/>
+                                <path d="M8 4.466V.534a.25.25 0 0 1 .41-.192l2.36 1.966c.12.1.12.284 0 .384L8.41 4.658A.25.25 0 0 1 8 4.466z"/>
+                            </svg>
+                            Refresh Status
+                        </a>
+                    </div>
+                </div>
+                <div class="card-footer text-muted">
+                    Last updated: <span id="page-load-time"></span> - (This page provides a snapshot. For real-time scan-by-scan feedback, check the I2C LCD on the Raspberry Pi.)
                 </div>
             </div>
-
-            {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                    <div class="mt-3">
-                        {% for category, message in messages %}
-                            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
-                                {{ message }}
-                                <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                                    <span aria-hidden="true">&times;</span>
-                                </button>
-                            </div>
-                        {% endfor %}
-                    </div>
-                {% endif %}
-            {% endwith %}
-
-            {% if scan_step == 'scan_booklet' and student_info %}
-                 {# Display last scan details if available, only in booklet scan step if a booklet was just processed #}
-                {% if last_scan_data %}
-                <div id="last_scan_info" class="mt-4 p-3 border rounded bg-light shadow-sm">
-                    <h4 class="text-success">Last Successful Scan:</h4>
-                    <p><strong>Student:</strong> {{ last_scan_data.student_name }} ({{ last_scan_data.student_id }})</p>
-                    <p><strong>Exam:</strong> {{ last_scan_data.exam_name }}</p>
-                    <p><strong>Booklet Code:</strong> {{ last_scan_data.booklet_code }}</p>
-                    <p><strong>Time:</strong> <span id="last_scan_time_rendered"></span></p>
-                    <script>
-                        document.getElementById('last_scan_time_rendered').textContent = new Date("{{ last_scan_data.timestamp }}").toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' });
-                    </script>
-                </div>
-                {% endif %}
-            {% endif %}
         </div>
     </div>
 </div>
 
 <script>
-document.addEventListener('DOMContentLoaded', function () {
-    const scanStep = "{{ scan_step }}";
-    const studentIdentifierInput = document.getElementById('student_identifier');
-    const bookletCodeInput = document.getElementById('booklet_code');
-    const examIdInput = document.getElementById('exam_id'); // Assuming this is the ID of the select element
+    document.addEventListener('DOMContentLoaded', function() {
+        document.getElementById('page-load-time').textContent = new Date().toLocaleTimeString();
 
-    if (scanStep === 'check_student') {
-        if (studentIdentifierInput) {
-            studentIdentifierInput.focus();
-        } else if (examIdInput) { // If student ID field isn't there (e.g. no exams)
-            examIdInput.focus();
-        }
-    } else if (scanStep === 'scan_booklet') {
-        if (bookletCodeInput) {
-            bookletCodeInput.focus();
-            bookletCodeInput.value = ''; // Ensure booklet field is clear for new scan
-        }
-    }
-
-    // Autofocus logic for student_identifier or booklet_code based on scan_step
-    // The autofocus HTML attribute on the relevant field should handle the initial focus.
-    // This script can handle focus after form submissions/re-renders if needed.
-
-    // Clear relevant fields for next input based on step, especially after successful operations
-    // This is now largely handled by redirects to specific states or by the route logic clearing form data.
-    // Example: after successful booklet scan, route redirects to 'check_student', effectively clearing for next student.
-    // After successful student check, route re-renders with booklet_code empty and focused.
-
-    // If student_info is available (meaning student was verified), perhaps make student_identifier readonly
-    {% if student_info and scan_step == 'scan_booklet' %}
-        if (studentIdentifierInput && !studentIdentifierInput.classList.contains('d-none')) { // Check if it's the visible input
-            // studentIdentifierInput.readOnly = true; // This was done by making it form-control-plaintext
-        }
-        if (examIdInput && !examIdInput.classList.contains('d-none')) {
-            // examIdInput.disabled = true; // This was done by making it form-control-plaintext
-        }
-    {% endif %}
-});
+        // Optional: Auto-refresh the page every 30 seconds if desired for a more "live" feel,
+        // but be mindful of server load if many admins have this open.
+        // setTimeout(function(){
+        //    window.location.reload(1);
+        // }, 30000); // 30 seconds
+    });
 </script>
 {% endblock %}

--- a/Booklet_Scan/app/utils/status_utils.py
+++ b/Booklet_Scan/app/utils/status_utils.py
@@ -1,0 +1,153 @@
+import json
+import os
+from datetime import datetime, timezone
+from flask import current_app
+
+# Path for the scan_status.json file (project root)
+# Assuming this util file is in app/utils/, so project root is three levels up.
+SCAN_STATUS_FILE_PATH = os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'scan_status.json')
+
+DEFAULT_STATUS = {
+    "active_exam_id": None,
+    "exam_name": None,
+    "expected_input_type": "none",
+    "verified_student_id": None,
+    "verified_student_name": None,
+    "status_timestamp": None # Will be set when written
+}
+
+def read_scan_status():
+    """Reads the scan_status.json file. Returns default status if not found or error."""
+    if not os.path.exists(SCAN_STATUS_FILE_PATH):
+        if current_app:
+            current_app.logger.warning(f"Status file not found: {SCAN_STATUS_FILE_PATH}. Returning default inactive status.")
+        else: # For scanner_listener running outside app context initially
+            print(f"Warning: Status file not found: {SCAN_STATUS_FILE_PATH}. Returning default inactive status.")
+        default_data = DEFAULT_STATUS.copy()
+        default_data["status_timestamp"] = datetime.now(timezone.utc).isoformat()
+        # Attempt to create it with default status if it's missing, to help scanner_listener
+        try:
+            with open(SCAN_STATUS_FILE_PATH, 'w') as f:
+                json.dump(default_data, f, indent=4)
+            if current_app: current_app.logger.info("Created default status file.")
+            else: print("Created default status file.")
+        except IOError:
+            if current_app: current_app.logger.error("Could not create default status file on read.")
+            else: print("Error: Could not create default status file on read.")
+        return default_data
+    try:
+        with open(SCAN_STATUS_FILE_PATH, 'r') as f:
+            status_data = json.load(f)
+            # Ensure all default keys are present
+            for key, value in DEFAULT_STATUS.items():
+                if key not in status_data:
+                    status_data[key] = value
+            return status_data
+    except (IOError, json.JSONDecodeError) as e:
+        if current_app:
+            current_app.logger.error(f"Error reading or parsing status file {SCAN_STATUS_FILE_PATH}: {e}")
+        else:
+            print(f"Error reading or parsing status file {SCAN_STATUS_FILE_PATH}: {e}")
+        default_data = DEFAULT_STATUS.copy()
+        default_data["status_timestamp"] = datetime.now(timezone.utc).isoformat()
+        return default_data
+
+
+def write_scan_status(status_data):
+    """Writes the given data to the scan_status.json file."""
+    try:
+        # Ensure all keys from DEFAULT_STATUS are present before writing
+        current_status_content = status_data.copy() # Work with a copy
+        for key, default_value in DEFAULT_STATUS.items():
+            if key not in current_status_content:
+                current_status_content[key] = default_value
+
+        current_status_content["status_timestamp"] = datetime.now(timezone.utc).isoformat() # Always update timestamp
+
+        with open(SCAN_STATUS_FILE_PATH, 'w') as f:
+            json.dump(current_status_content, f, indent=4)
+
+        log_message = f"Scan status updated: {current_status_content}"
+        if current_app:
+            current_app.logger.info(log_message)
+        else:
+            print(log_message) # Fallback for scripts
+    except IOError as e:
+        log_message_err = f"Error writing scan status file: {e}"
+        if current_app:
+            current_app.logger.error(log_message_err)
+        else:
+            print(log_message_err)
+
+
+def clear_scan_status():
+    """Clears the scan status, indicating no active exam for scanning."""
+    status_to_write = DEFAULT_STATUS.copy()
+    # No need to set timestamp here, write_scan_status will do it.
+    write_scan_status(status_to_write)
+
+
+def initialize_scan_status_file():
+    """Initializes the scan status file if it doesn't exist or is invalid."""
+    if not os.path.exists(SCAN_STATUS_FILE_PATH):
+        if current_app: current_app.logger.info(f"Status file not found at {SCAN_STATUS_FILE_PATH}, initializing.")
+        else: print(f"Status file not found at {SCAN_STATUS_FILE_PATH}, initializing.")
+        clear_scan_status()
+    else:
+        # Validate existing file content, clear if malformed
+        try:
+            with open(SCAN_STATUS_FILE_PATH, 'r') as f:
+                data = json.load(f)
+                if not all(key in data for key in ["active_exam_id", "expected_input_type"]):
+                    if current_app: current_app.logger.warning("Scan status file is malformed. Re-initializing.")
+                    else: print("Warning: Scan status file is malformed. Re-initializing.")
+                    clear_scan_status()
+        except (json.JSONDecodeError, IOError) as e:
+            log_message_err = f"Error reading scan status file during init: {e}. Re-initializing."
+            if current_app: current_app.logger.error(log_message_err)
+            else: print(log_message_err)
+            clear_scan_status()
+
+if __name__ == '__main__':
+    # Test functions (if run directly, current_app won't be available)
+    print("Testing status_utils.py...")
+    if os.path.exists(SCAN_STATUS_FILE_PATH):
+        os.remove(SCAN_STATUS_FILE_PATH)
+
+    print("\n1. Initializing file (should create with defaults):")
+    initialize_scan_status_file() # Relies on print for logging without app context
+    print(f"File exists: {os.path.exists(SCAN_STATUS_FILE_PATH)}")
+    current_data = read_scan_status()
+    print(f"Read data: {current_data}")
+    assert current_data["active_exam_id"] is None
+
+    print("\n2. Writing new status:")
+    new_data = {
+        "active_exam_id": 123,
+        "exam_name": "Test Exam",
+        "expected_input_type": "student",
+        "verified_student_id": None,
+        "verified_student_name": None
+    }
+    write_scan_status(new_data)
+    current_data = read_scan_status()
+    print(f"Read data: {current_data}")
+    assert current_data["active_exam_id"] == 123
+    assert current_data["expected_input_type"] == "student"
+
+    print("\n3. Clearing status:")
+    clear_scan_status()
+    current_data = read_scan_status()
+    print(f"Read data: {current_data}")
+    assert current_data["active_exam_id"] is None
+    assert current_data["expected_input_type"] == "none"
+
+    print("\n4. Testing read_scan_status with missing file (should recreate):")
+    if os.path.exists(SCAN_STATUS_FILE_PATH):
+        os.remove(SCAN_STATUS_FILE_PATH)
+    current_data = read_scan_status()
+    print(f"Read data after delete & read: {current_data}")
+    assert current_data["active_exam_id"] is None
+    assert os.path.exists(SCAN_STATUS_FILE_PATH)
+
+    print("\nTest complete.")

--- a/Booklet_Scan/requirements.txt
+++ b/Booklet_Scan/requirements.txt
@@ -6,3 +6,5 @@ Flask-WTF>=0.15 # For forms
 Flask-Bootstrap>=1.0 # For Bootstrap styling and wtf.html
 RPLCD>=1.0 # For I2C LCD Display on Raspberry Pi
 smbus-cffi>=0.5.1 # Often needed by RPLCD on newer Python/Pi for I2C communication
+evdev>=1.6.1 # For direct barcode scanner input on Linux/Pi
+requests>=2.25.1 # For scanner_listener.py to make HTTP requests to Flask API

--- a/Booklet_Scan/scanner_listener.py
+++ b/Booklet_Scan/scanner_listener.py
@@ -1,0 +1,207 @@
+import os
+import time
+import json
+import logging
+import requests
+from evdev import InputDevice, categorize, ecodes, list_devices
+
+# --- Configuration ---
+# Placeholder: User needs to replace this with the actual event device path for their scanner
+# Example: '/dev/input/event3'. Find yours with `sudo libinput list-devices` or check /dev/input/by-id/
+SCANNER_DEVICE_PATH = None # OR "/dev/input/by-id/usb-SYMBEYE_Barcode_Scanner_SYMBEYE_Barcode_Scanner-event-kbd"
+
+# Flask API endpoint for submitting scans
+FLASK_API_ENDPOINT = "http://127.0.0.1:5000/api/v1/internal_scan"
+
+# Path to the scan_status.json file (relative to this script, assuming it's in Booklet_Scan/)
+STATUS_FILE_PATH = os.path.join(os.path.dirname(__file__), 'scan_status.json')
+
+# Logging setup
+LOG_FILE = os.path.join(os.path.dirname(__file__), 'scanner_listener.log')
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler() # Also print to console
+    ]
+)
+
+# --- Key Mapping (Simplified US QWERTY layout) ---
+# Does not handle Shift, CapsLock, etc. for simplicity, as barcodes usually use simple chars/digits.
+# Customize if your barcodes use other characters or your scanner has a different layout.
+KEYCODE_MAP = {
+    ecodes.KEY_1: '1', ecodes.KEY_2: '2', ecodes.KEY_3: '3', ecodes.KEY_4: '4', ecodes.KEY_5: '5',
+    ecodes.KEY_6: '6', ecodes.KEY_7: '7', ecodes.KEY_8: '8', ecodes.KEY_9: '9', ecodes.KEY_0: '0',
+    ecodes.KEY_A: 'A', ecodes.KEY_B: 'B', ecodes.KEY_C: 'C', ecodes.KEY_D: 'D', ecodes.KEY_E: 'E',
+    ecodes.KEY_F: 'F', ecodes.KEY_G: 'G', ecodes.KEY_H: 'H', ecodes.KEY_I: 'I', ecodes.KEY_J: 'J',
+    ecodes.KEY_K: 'K', ecodes.KEY_L: 'L', ecodes.KEY_M: 'M', ecodes.KEY_N: 'N', ecodes.KEY_O: 'O',
+    ecodes.KEY_P: 'P', ecodes.KEY_Q: 'Q', ecodes.KEY_R: 'R', ecodes.KEY_S: 'S', ecodes.KEY_T: 'T',
+    ecodes.KEY_U: 'U', ecodes.KEY_V: 'V', ecodes.KEY_W: 'W', ecodes.KEY_X: 'X', ecodes.KEY_Y: 'Y',
+    ecodes.KEY_Z: 'Z',
+    ecodes.KEY_MINUS: '-', ecodes.KEY_EQUAL: '=', ecodes.KEY_SLASH: '/', ecodes.KEY_BACKSLASH: '\\',
+    ecodes.KEY_SPACE: ' ', ecodes.KEY_DOT: '.', ecodes.KEY_COMMA: ',',
+    # Add more mappings as needed based on typical barcode content
+    # Numeric keypad keys might also be relevant depending on scanner config
+    ecodes.KEY_KP1: '1', ecodes.KEY_KP2: '2', ecodes.KEY_KP3: '3', ecodes.KEY_KP4: '4',
+    ecodes.KEY_KP5: '5', ecodes.KEY_KP6: '6', ecodes.KEY_KP7: '7', ecodes.KEY_KP8: '8',
+    ecodes.KEY_KP9: '9', ecodes.KEY_KP0: '0', ecodes.KEY_KPDOT: '.',
+    ecodes.KEY_KPSLASH: '/', ecodes.KEY_KPASTERISK: '*', ecodes.KEY_KPMINUS: '-',
+    ecodes.KEY_KPPLUS: '+', ecodes.KEY_KPENTER: '\n', # Assuming KPEnter means end of scan
+    ecodes.KEY_ENTER: '\n' # Assuming Enter means end of scan
+}
+
+def find_scanner_device():
+    """Attempts to find a suitable scanner device automatically or guides the user."""
+    global SCANNER_DEVICE_PATH
+    if SCANNER_DEVICE_PATH and os.path.exists(SCANNER_DEVICE_PATH):
+        logging.info(f"Using pre-configured scanner path: {SCANNER_DEVICE_PATH}")
+        return SCANNER_DEVICE_PATH
+
+    devices = [InputDevice(path) for path in list_devices()]
+    scanners = []
+    for device in devices:
+        # Heuristic: scanners often have "scan" or "hid" in name and EV_KEY capability
+        # This is very basic and might need refinement for specific hardware
+        name_lower = device.name.lower()
+        if ("scan" in name_lower or "barcod" in name_lower or "hid" in name_lower or "keyboard" in name_lower):
+            capabilities = device.capabilities(verbose=False)
+            if ecodes.EV_KEY in capabilities:
+                scanners.append({'path': device.path, 'name': device.name})
+
+    if not scanners:
+        logging.error("No potential scanner devices found automatically.")
+        logging.info("Please manually identify your scanner's event device path (e.g., /dev/input/eventX).")
+        logging.info("You can try tools like 'sudo libinput list-devices' or check '/dev/input/by-id/'.")
+        logging.info("Then, set SCANNER_DEVICE_PATH at the top of this script.")
+        return None
+
+    if len(scanners) == 1:
+        SCANNER_DEVICE_PATH = scanners[0]['path']
+        logging.info(f"Automatically selected scanner: {scanners[0]['name']} on {SCANNER_DEVICE_PATH}")
+        return SCANNER_DEVICE_PATH
+    else:
+        logging.warning("Multiple potential scanner devices found:")
+        for i, s in enumerate(scanners):
+            logging.warning(f"  {i}: {s['name']} ({s['path']})")
+        logging.info("Please choose one and set SCANNER_DEVICE_PATH at the top of this script.")
+        # You could add interactive selection here if running interactively,
+        # but for a background script, pre-configuration is better.
+        return None
+
+
+def read_scan_status():
+    """Reads the scan_status.json file."""
+    try:
+        if not os.path.exists(STATUS_FILE_PATH):
+            # logging.warning(f"Status file not found: {STATUS_FILE_PATH}. Assuming no active scan.")
+            return None # Or a default "inactive" status
+        with open(STATUS_FILE_PATH, 'r') as f:
+            status_data = json.load(f)
+            return status_data
+    except (IOError, json.JSONDecodeError) as e:
+        logging.error(f"Error reading or parsing status file {STATUS_FILE_PATH}: {e}")
+        return None
+
+def post_scan_data(payload):
+    """Posts the scanned data to the Flask API."""
+    try:
+        response = requests.post(FLASK_API_ENDPOINT, json=payload, timeout=5)
+        response.raise_for_status() # Raise an exception for HTTP errors (4xx or 5xx)
+        logging.info(f"Data posted successfully: {payload}. Response: {response.json()}")
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        logging.error(f"Error posting data to Flask API: {e}")
+        return None
+
+def main_loop():
+    """Main loop to listen for scanner input and process it."""
+    effective_scanner_path = find_scanner_device()
+    if not effective_scanner_path:
+        logging.error("Scanner device not configured or found. Exiting.")
+        return
+
+    try:
+        device = InputDevice(effective_scanner_path)
+        device.grab() # Grab device to prevent other applications (like X server) from getting events
+        logging.info(f"Listening for barcode scans on {device.name} ({effective_scanner_path})...")
+    except Exception as e:
+        logging.error(f"Failed to open or grab scanner device {effective_scanner_path}: {e}")
+        logging.error("Ensure this script has permissions (e.g., run with sudo or set udev rules).")
+        return
+
+    barcode_buffer = []
+    try:
+        for event in device.read_loop():
+            if event.type == ecodes.EV_KEY:
+                key_event = categorize(event)
+                if key_event.keystate == key_event.key_down: # Process on key press
+                    keycode = key_event.scancode # or key_event.keycode for a more abstract representation
+
+                    char = KEYCODE_MAP.get(keycode)
+
+                    if char == '\n': # End of barcode (Enter key)
+                        if barcode_buffer:
+                            scanned_string = "".join(barcode_buffer)
+                            logging.info(f"Barcode scanned: {scanned_string}")
+
+                            status = read_scan_status()
+                            if status and status.get("active_exam_id") and status.get("expected_input_type") != "none":
+                                api_payload = {
+                                    "scanned_data": scanned_string,
+                                    "data_type": status["expected_input_type"],
+                                    "active_exam_id": status["active_exam_id"]
+                                }
+                                if status["expected_input_type"] == "booklet" and status.get("verified_student_id"):
+                                    api_payload["verified_student_id"] = status["verified_student_id"]
+
+                                post_scan_data(api_payload)
+                            else:
+                                logging.warning(f"Scan '{scanned_string}' received, but no active exam or invalid status. Ignoring.")
+
+                            barcode_buffer = [] # Clear buffer for next scan
+                        else:
+                            logging.debug("Enter pressed with empty buffer, ignoring.")
+                    elif char: # Regular character
+                        barcode_buffer.append(char)
+                    else:
+                        logging.debug(f"Unknown keycode pressed: {keycode}")
+    except KeyboardInterrupt:
+        logging.info("Scanner listener stopped by user.")
+    except Exception as e:
+        logging.error(f"An error occurred in the main loop: {e}")
+    finally:
+        if 'device' in locals() and device:
+            try:
+                device.ungrab()
+                device.close()
+                logging.info("Scanner device ungrabbed and closed.")
+            except Exception as e_close:
+                logging.error(f"Error closing device: {e_close}")
+
+
+if __name__ == "__main__":
+    logging.info("Starting scanner listener script...")
+    # Small delay to allow Flask app to start if both are launched together
+    # time.sleep(5) # Uncomment if needed, but status file check should handle races
+
+    # Initialize status file from listener side if it's missing, so it doesn't crash on first read
+    # This is mostly for dev. In prod, Flask app should manage this.
+    if not os.path.exists(STATUS_FILE_PATH):
+        logging.info(f"Status file {STATUS_FILE_PATH} not found. Creating a default inactive one.")
+        # Create a default inactive status file
+        default_status = {
+            "active_exam_id": None, "exam_name": None, "expected_input_type": "none",
+            "verified_student_id": None, "verified_student_name": None,
+            "status_timestamp": datetime.now(timezone.utc).isoformat()
+        }
+        try:
+            with open(STATUS_FILE_PATH, 'w') as f_status:
+                json.dump(default_status, f_status, indent=4)
+        except IOError as e_io:
+            logging.error(f"Could not create initial status file: {e_io}")
+
+    main_loop()
+    logging.info("Scanner listener script finished.")
+
+```

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 ## Project Overview
 
-BookletScan Pro is a Flask-based web application designed to streamline the management and scanning of exam booklets. It provides administrators with tools to manage students, examination venues, and exam schedules, and assign students to specific exams. The core functionality includes a scanning interface for recording exam booklet codes against students for selected exams, supporting both manual input and USB barcode scanner integration.
+BookletScan Pro is a Flask-based web application designed to streamline the management and scanning of exam booklets. It's optimized for use with a Raspberry Pi running in headless mode, using a directly connected USB barcode scanner and an I2C LCD for local feedback. Administrators can manage the system via a web dashboard accessible over the network.
 
-The system aims to improve efficiency and accuracy in tracking exam booklet submissions.
+The system aims to improve efficiency and accuracy in tracking exam booklet submissions by providing immediate local feedback on the Pi's LCD and centralized data management.
 
 ## Features
 
@@ -12,23 +12,19 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
     *   Secure login/logout for administrators.
     *   Admin self-registration.
 *   **Data Management (Admin Panel):**
-    *   **Students:** Create, Read, Update, Delete (CRUD) student records (Name, Student ID, Course).
-    *   **Venues:** CRUD operations for examination venues (Name, Location, Capacity).
-    *   **Exams:** CRUD operations for exams (Name, Course, Venue, Date, Start/End Times).
-    *   **Student-Exam Assignments:** Assign students to specific exams and manage these assignments.
-*   **Booklet Scanning:**
-    *   User-friendly interface to select an active exam.
-    *   Input for booklet code and student identifier (supports manual typing and USB barcode scanners).
-    *   Validation:
-        *   Checks for valid student ID.
-        *   Warns if a student is not formally assigned to the selected exam (but allows scan).
-        *   Prevents duplicate booklet code scans for the same exam.
-    *   Real-time feedback on scan success or failure.
-    *   Display of last successfully scanned item details.
+    *   CRUD operations for Students, Venues, Exams, Courses, and Student-Exam Assignments.
+*   **Headless Booklet Scanning (Raspberry Pi):**
+    *   Utilizes a background Python script (`scanner_listener.py`) on the Raspberry Pi to read directly from a connected USB barcode scanner (using `evdev`).
+    *   Scanned data is sent to an internal API in the Flask application.
+    *   The Flask app processes the scan (student validation, booklet recording) and provides real-time feedback on an I2C LCD display connected to the Pi.
+    *   Admins control the start/stop of scanning sessions for exams via the web dashboard.
+    *   The web interface's `/scan` page acts as a status display for remote monitoring.
+*   **I2C LCD Display Integration:**
+    *   Shows Pi's IP address on startup.
+    *   Displays active exam information and instructions when a scanning session is started by an admin.
+    *   Provides immediate local feedback for each scan (student eligibility, success/error messages).
 *   **Modern User Interface:**
-    *   Clean, responsive design using the "Minty" Bootswatch theme.
-    *   Card-based layouts for dashboards and forms.
-    *   Improved table styling and user action buttons with icons.
+    *   Clean, responsive design using the "Minty" Bootswatch theme for the web dashboard.
 
 ## Technology Stack
 
@@ -37,10 +33,15 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
     *   **Flask-Login:** User session management (for admins)
     *   **Flask-WTF:** Forms creation and validation
     *   **Werkzeug:** Password hashing and utility functions
-*   **Frontend:**
+    *   **evdev:** For direct barcode scanner input on Linux/Raspberry Pi (headless mode).
+    *   **requests:** Used by the scanner listener script to communicate with the Flask API.
+*   **Frontend (Admin Web Dashboard):**
     *   HTML5, CSS3
     *   **Bootstrap 4 (via Bootswatch "Minty" theme):** Responsive design and UI components
-    *   JavaScript (minimal, for UI enhancements like feedback on scan page)
+    *   JavaScript (minimal, for UI enhancements)
+*   **Hardware (Raspberry Pi):**
+    *   I2C LCD Display (e.g., 16x2)
+    *   USB Barcode Scanner (HID keyboard emulation type)
 *   **Database:** SQLite (default, configurable in `config.py`)
 
 ## Setup and Installation
@@ -49,6 +50,14 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
     *   Python 3.8+
     *   `pip` (Python package installer)
     *   Git (for cloning the repository)
+    *   **(For Raspberry Pi deployment with scanner):** System libraries for `evdev`. On Debian-based systems (like Raspberry Pi OS):
+        ```bash
+        sudo apt update
+        sudo apt install python3-dev libudev-dev pkg-config
+        # It's also often good to install python3-evdev via apt if available,
+        # or pip will compile it using the headers above.
+        # sudo apt install python3-evdev
+        ```
 
 2.  **Clone the Repository:**
     ```bash
@@ -58,26 +67,29 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
     *(Replace `<repository_url>` with the actual URL of your Git repository)*
 
 3.  **Create and Activate a Virtual Environment:**
-    *   **Windows:**
+    *   **Windows (for development of web panel only, not for Pi scanner listener):**
         ```bash
         python -m venv venv
         venv\Scripts\activate
         ```
-    *   **macOS/Linux:**
+    *   **macOS/Linux (and Raspberry Pi):**
         ```bash
         python3 -m venv venv
         source venv/bin/activate
         ```
 
 4.  **Install Dependencies:**
-    ```bash
-    pip install -r requirements.txt
-    ```
+    *   Ensure virtual environment is active.
+    *   Install Python packages:
+        ```bash
+        pip install -r requirements.txt
+        ```
 
 5.  **Database Initialization:**
     The application uses Flask-SQLAlchemy. The database (`app.db` by default, located in the `Booklet_Scan` directory) will be created automatically if it doesn't exist when the application first tries to access it. 
+    The `scan_status.json` file (used for headless scanning coordination) will also be created/initialized automatically in the `Booklet_Scan` directory upon first admin access or when the scanner listener script starts.
     
-    To initialize it manually (e.g., after cloning or if you've deleted `app.db`):
+    To initialize the database manually (e.g., after cloning or if you've deleted `app.db`):
     *   Ensure your virtual environment is activated.
     *   Open a Python REPL in your project's root directory (`Booklet_Scan`):
         ```bash
@@ -90,7 +102,7 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
         print("Database tables created.")
         exit()
         ```
-    *   **(Note:** For more complex database schema changes in a production environment, consider integrating `Flask-Migrate`.)*
+    *   **Important for schema changes (like adding `exam_status`):** `db.create_all()` will NOT modify existing tables. If you are updating an existing deployment and have modified models, you will need to either use a migration tool (like Flask-Migrate, not currently integrated) or manually alter your database schema (e.g., `ALTER TABLE exam ADD COLUMN exam_status VARCHAR(30) DEFAULT 'Pending' NOT NULL;`). For development, deleting `app.db` will allow it to be recreated with the new schema.
 
 6.  **Create an Initial Admin User (Optional if using self-registration):**
     If you want to create an admin user programmatically before the first run (or if you prefer not to use the self-registration form initially):
@@ -113,141 +125,186 @@ The system aims to improve efficiency and accuracy in tracking exam booklet subm
         exit()
         ```
 
-## Running the Application
+## Running the Application (Flask Web Server on Raspberry Pi)
 
-1.  Ensure your virtual environment is activated from the `Booklet_Scan` directory.
+1.  Ensure your virtual environment is activated from the `Booklet_Scan` directory on the Raspberry Pi.
 2.  Run the Flask development server using the `run.py` script:
     ```bash
-    python run.py
+    python3 run.py
     ```
-3.  The application will typically be available at `http://127.0.0.1:5000/`.
+3.  The application will typically be available at `http://<your_pi_ip_address>:5000/` for access from other devices on the network, or `http://127.0.0.1:5000/` from the Pi itself.
 
-## Usage
+## Headless Raspberry Pi Scanning Setup
 
-1.  **Admin Registration/Login:**
-    *   Navigate to the application URL (e.g., `http://127.0.0.1:5000/`). You should be redirected to the login page.
-    *   If you are a new admin and haven't created an account via `flask shell`, click the "New User? Click to Register!" link on the login page and create an account.
-    *   Log in with your admin credentials.
+This system is designed for a Raspberry Pi to handle barcode scanning directly via a connected USB scanner and display feedback on an I2C LCD, even without a monitor connected to the Pi (headless mode). The Flask web application runs on the Pi, and administrators can control and monitor the scanning process via a web browser on a separate computer on the same network.
 
-2.  **Admin Dashboard:**
-    *   After successful login, you'll be directed to the Admin Dashboard.
-    *   This dashboard provides quick links to manage Students, Venues, Exams, and Student-Exam Assignments.
+### Core Components for Headless Scanning:
 
-3.  **Managing Entities (Students, Venues, Exams, Assignments):**
-    *   Click on the respective "Manage" button on the dashboard (e.g., "Manage Students").
-    *   Each management section provides a list view of existing records.
-    *   You can add new entities using the "Add New..." button.
-    *   Edit existing records using the "Edit" button next to each entry.
-    *   Delete records using the "Delete" button (a confirmation will be required).
-
-4.  **Booklet Scanning Interface:**
-    *   Access the scanning interface via the "Scan Booklets" link in the top navigation bar or the large green button on the Admin Dashboard.
-    *   **Select the Exam:** Choose the current exam from the "Select Exam" dropdown list. This is crucial for associating scans correctly.
-    *   **Enter Student ID:** Type the Student's ID or scan it if it's barcoded/QR coded.
-    *   **Enter Booklet Code:** Type the Booklet Code or scan it from the exam booklet.
-    *   **Submit:** Click the "Record Scan" button. If your USB scanner is configured to send an "Enter" key press after scanning, it should automatically submit the form data for the focused field (typically the booklet code field).
-    *   The system will provide immediate feedback:
-        *   **Success:** A green message confirming the scan, and the "Last Scan Details" section will update.
-        *   **Warning:** Yellow messages for issues like "Student not assigned to this exam" or "Booklet already scanned."
-        *   **Error:** Red messages for critical issues like "Student ID not found."
-    *   After a successful scan, the Student ID and Booklet Code fields will clear, and the cursor will return to the Booklet Code field, ready for the next scan.
-
-## Future Considerations/Improvements
-
-*   **Flask-Migrate:** Implement database migrations for robust schema updates, especially in production.
-*   **Advanced Scan Record Viewing/Reporting:** Create a dedicated page for administrators to view, filter, search, and possibly export scan records (e.g., as CSV).
-*   **Student-Specific View:** Potentially a view for students to check their registered exams or confirm their scan status (this would require implementing student authentication and user roles beyond just admins).
-*   **Enhanced Barcode Logic/Parsing:** If booklet codes or student IDs are embedded within a single more complex barcode, add parsing logic to extract the necessary information.
-*   **API Endpoints:** Develop API endpoints for programmatic interaction, e.g., bulk data import or integration with other institutional systems.
-*   **Comprehensive Testing:** Expand unit and integration tests to ensure reliability.
-*   **Configuration for Production:** Detail steps for deploying to a production environment (e.g., using Gunicorn/Waitress, different database).
-
-## Raspberry Pi Deployment with I2C LCD
-
-This application can be run on a Raspberry Pi with an I2C LCD display to show scan status.
+1.  **Flask Web Application (`run.py`):**
+    *   Runs on the Raspberry Pi.
+    *   Serves the admin web dashboard and an internal API.
+    *   Controls the I2C LCD display.
+    *   Manages the overall state of scanning (active exam, expected input type) via `scan_status.json`.
+2.  **Scanner Listener Script (`scanner_listener.py`):**
+    *   A separate Python script that runs in the background on the Raspberry Pi.
+    *   Directly reads input from the USB barcode scanner using the `evdev` library.
+    *   Communicates with the Flask application by POSTing scanned data to an internal API endpoint (`/api/v1/internal_scan`).
+    *   Reads `scan_status.json` to know the current context (active exam, student vs. booklet scan).
+3.  **I2C LCD Display:**
+    *   Connected to the Raspberry Pi.
+    *   Provides immediate local feedback for scans (e.g., student eligibility, scan success/failure), IP address, and active exam status.
+4.  **`scan_status.json` file:**
+    *   Located in the `Booklet_Scan` project root.
+    *   Stores the current state of the scanning process (e.g., `active_exam_id`, `expected_input_type`).
+    *   Used to coordinate between the Flask app (controlled by admin via web) and `scanner_listener.py`.
 
 ### Hardware Setup:
 
-1.  **I2C LCD Display:** A standard I2C LCD, typically 16x2 or 20x4 characters, often using a PCF8574 I2C backpack.
-2.  **Wiring:**
-    *   **SDA (Serial Data):** Connect to Raspberry Pi GPIO2 (Pin 3).
-    *   **SCL (Serial Clock):** Connect to Raspberry Pi GPIO3 (Pin 5).
-    *   **VCC:** Connect to Raspberry Pi 5V (Pin 2 or 4).
-    *   **GND:** Connect to Raspberry Pi Ground (Pin 6, 9, 14, 20, 25, 30, 34, or 39).
-    *   *Always double-check your Raspberry Pi pinout and LCD datasheet.*
+*   **Raspberry Pi:** With Raspberry Pi OS, network connectivity.
+*   **I2C LCD Display:** Wired as per standard I2C LCD setup (SDA, SCL, VCC, GND - typically GPIO2 for SDA, GPIO3 for SCL).
+*   **USB Barcode Scanner:** Connected to a USB port on the Raspberry Pi. Assumed to operate as a standard HID keyboard device.
 
-### Raspberry Pi Software Configuration:
+### Software and Configuration Steps on Raspberry Pi:
 
-1.  **Operating System:**
-    *   Install Raspberry Pi OS (formerly Raspbian), either Lite (headless) or Desktop version. Flash it to an SD card.
+1.  **Clone Repository & Install Dependencies:**
+    *   Follow main "Setup and Installation" steps 1-4. This includes installing system dependencies like `python3-dev`, `libudev-dev` (for `evdev`) and then `pip install -r requirements.txt`.
 
-2.  **Initial Setup:**
-    *   Boot the Raspberry Pi and perform initial setup (locale, keyboard, network).
-    *   Ensure your Pi is connected to the internet.
+2.  **Enable I2C Interface:**
+    *   Done via `sudo raspi-config` (Interface Options > I2C > Enable). Verify with `sudo i2cdetect -y 1` (or `0` for old Pi models).
 
-3.  **Enable I2C Interface:**
-    *   Open a terminal on the Raspberry Pi.
-    *   Run `sudo raspi-config`.
-    *   Navigate to `Interface Options` (or `Interfacing Options`).
-    *   Select `I2C` and enable it.
-    *   Reboot the Raspberry Pi if prompted.
-
-4.  **Install System Dependencies:**
-    *   Update package lists: `sudo apt update && sudo apt upgrade -y`
-    *   Install necessary tools and libraries:
-        ```bash
-        sudo apt install -y python3-dev python3-pip i2c-tools libffi-dev git
+3.  **Configure `scanner_listener.py`:**
+    *   Open `Booklet_Scan/scanner_listener.py` in an editor.
+    *   **Identify Scanner Device Path:** You need to find the event device path for your USB barcode scanner.
+        *   Connect your scanner.
+        *   Try running `sudo libinput list-devices`. Look for your scanner. Note its `/dev/input/eventX` path.
+        *   Alternatively, check `/dev/input/by-id/`. Often USB HID devices have descriptive names here (e.g., `usb-SYMBEYE_Barcode_Scanner_...-event-kbd`). Using a path from `/dev/input/by-id/` is more stable across reboots than `/dev/input/eventX`.
+    *   **Update `SCANNER_DEVICE_PATH`:** In `scanner_listener.py`, change the line:
+        ```python
+        SCANNER_DEVICE_PATH = None
         ```
-        *   `i2c-tools`: Allows you to detect I2C devices.
-        *   `libffi-dev`: May be needed for `cffi`, a dependency of `smbus-cffi`.
-
-5.  **Verify I2C Connection:**
-    *   With the LCD wired up and Pi powered on, run:
-        ```bash
-        sudo i2cdetect -y 1
+        to your scanner's actual path, e.g.:
+        ```python
+        SCANNER_DEVICE_PATH = "/dev/input/by-id/usb-Your_Scanner_Name-event-kbd"
+        # or SCANNER_DEVICE_PATH = "/dev/input/event3"
         ```
-        (Use `i2cdetect -y 0` if you have a very old Model B Rev 1 Pi).
-    *   You should see a grid. The address of your LCD (e.g., `27` or `3F`) should appear. Note this address. The default in `app/utils/lcd_display.py` is `0x27`. If yours is different, you might need to adjust the `DEFAULT_I2C_ADDRESS` in that file or modify the `init_lcd` call.
+    *   Review `KEYCODE_MAP` in the script if your scanner outputs non-standard characters or keycodes, or doesn't automatically send an 'Enter' keystroke.
 
-### Application Setup on Raspberry Pi:
-
-1.  **Clone the Repository:**
-    ```bash
-    git clone <your_repository_url>
-    cd Booklet_Scan # Or your project's root directory
-    ```
-
-2.  **Create and Activate Virtual Environment:**
-    ```bash
-    python3 -m venv venv
-    source venv/bin/activate
-    ```
-
-3.  **Install Python Dependencies:**
-    ```bash
-    pip3 install -r requirements.txt
-    ```
-    This will install Flask, RPLCD, smbus-cffi, and other necessary packages.
-
-4.  **Database Setup:**
-    *   Follow the database initialization steps outlined in the main "Setup and Installation" section (using `flask shell` and `db.create_all()`).
-
-5.  **Run the Application for Network Access:**
-    *   To make the Flask app accessible from other devices on your network, run it on host `0.0.0.0`:
+4.  **Test `scanner_listener.py` (Optional but Recommended):**
+    *   You can try running it directly first to see if it detects your scanner and reads barcodes.
+    *   You might need to run it with `sudo` due to permissions for `/dev/input/` devices:
         ```bash
+        cd Booklet_Scan
+        sudo python3 scanner_listener.py
+        ```
+    *   Scan some barcodes. It will attempt to POST to the Flask API (which might not be running yet for this test, so expect connection errors in the listener log, but it should log the scanned string). Press Ctrl+C to stop.
+
+5.  **Set Up `scanner_listener.py` to Run as a Background Service (using `systemd`):**
+    *   Create a service file, e.g., `/etc/systemd/system/scanner_listener.service`:
+        ```ini
+        [Unit]
+        Description=Booklet Scan Scanner Listener Service
+        After=network.target multi-user.target # Ensure network is up, and Flask app service if separate
+
+        [Service]
+        ExecStart=/home/pi/Exam_BookLet/Booklet_Scan/venv/bin/python3 /home/pi/Exam_BookLet/Booklet_Scan/scanner_listener.py
+        WorkingDirectory=/home/pi/Exam_BookLet/Booklet_Scan/
+        StandardOutput=append:/var/log/scanner_listener.log # Log to a file
+        StandardError=append:/var/log/scanner_listener.error.log # Log errors to a file
+        Restart=always
+        User=pi # Or the user you run the app as. Ensure this user has permissions for scanner device.
+        # Environment="PYTHONUNBUFFERED=1" # Useful for immediate logging
+
+        [Install]
+        WantedBy=multi-user.target
+        ```
+        *   **Adjust paths** (`ExecStart`, `WorkingDirectory`) to match your project location and virtual environment.
+        *   **Permissions for Scanner:** The `User=pi` might not have direct access to `/dev/input/eventX`. You have a few options:
+            *   Run as `User=root` (simpler, but less secure).
+            *   **Recommended:** Create a `udev` rule to grant your user (e.g., `pi`) access to the scanner device. Create a file like `/etc/udev/rules.d/99-scanner.rules`:
+                ```
+                SUBSYSTEM=="input", KERNEL=="event[0-9]*", ATTRS{name}=="*Your Scanner Device Name*", MODE="0660", GROUP="input", TAG+="uaccess"
+                ```
+                Replace `"Your Scanner Device Name"` (get from `libinput list-devices` or `cat /proc/bus/input/devices`). Ensure user `pi` is part of the `input` group (`sudo usermod -a -G input pi`). Then run `sudo udevadm control --reload-rules && sudo udevadm trigger`.
+    *   Enable and start the service:
+        ```bash
+        sudo systemctl daemon-reload
+        sudo systemctl enable scanner_listener.service
+        sudo systemctl start scanner_listener.service
+        ```
+    *   Check its status: `sudo systemctl status scanner_listener.service`
+        View logs: `journalctl -u scanner_listener.service -f` or check `/var/log/scanner_listener.log`.
+
+6.  **Run the Flask Web Application:**
+    *   This can also be run as a systemd service for robustness. Example `/etc/systemd/system/booklet_scan_web.service`:
+        ```ini
+        [Unit]
+        Description=BookletScan Pro Flask Web Application
+        After=network.target
+
+        [Service]
+        User=pi
+        WorkingDirectory=/home/pi/Exam_BookLet/Booklet_Scan
+        ExecStart=/home/pi/Exam_BookLet/Booklet_Scan/venv/bin/gunicorn --workers 2 --bind 0.0.0.0:5000 "run:app"
+        Restart=always
+        # StandardOutput=append:/var/log/booklet_scan_web.log
+        # StandardError=append:/var/log/booklet_scan_web.error.log
+
+        [Install]
+        WantedBy=multi-user.target
+        ```
+        * Install Gunicorn: `pip install gunicorn` (add to `requirements.txt`).
+        * Adjust paths and user. Then enable and start this service.
+    *   Alternatively, for simpler setup, run manually in a `screen` or `tmux` session:
+        ```bash
+        cd Booklet_Scan
+        source venv/bin/activate
         python3 run.py
         ```
-        (Ensure `run.py` is configured to run on `host='0.0.0.0'`, or use `flask run --host=0.0.0.0`).
-    *   The application will be available at `http://<RaspberryPi_IP_Address>:5000`. Find your Pi's IP address using `hostname -I`.
+    *   The Flask app will run on `http://<Your_Pi_IP>:5000`.
 
-### LCD Functionality:
+### Usage Workflow with Headless Setup:
 
-*   The `app/utils/lcd_display.py` module handles LCD interaction.
-*   It attempts to initialize the LCD when the scan page (`/scan`) is first accessed or when a message needs to be displayed.
-*   If the LCD is not detected or an error occurs, messages will be printed to the console/Flask log instead, and the web application will continue to function.
-*   The scan route (`app/main/routes.py`) will send status messages to the LCD:
-    *   "System Ready" on initialization.
-    *   "Error: No Exams Setup" if no exams are configured.
-    *   Scan results: Student ID, eligibility ("Eligible" or "Warn:NotAssigned"), or error messages like "Student Not Found", "Warn: Duplicate".
-    *   Form validation errors from the web page may also show a concise message.
+1.  **Admin (Remote Web Browser):**
+    *   Accesses `http://<Pi_IP_Address>:5000`.
+    *   Logs in to the admin dashboard.
+    *   Navigates to "Manage Exams".
+    *   Clicks "Start Auth" for the desired exam.
+        *   This updates `scan_status.json` on the Pi.
+        *   The I2C LCD on the Pi updates to show exam info and "Scan Student ID".
+        *   The `scanner_listener.py` script (reading `scan_status.json`) now knows an exam is active and what to expect.
+
+2.  **Scanning (at the Pi, via USB Scanner):**
+    *   The person at the Pi scans a **Student ID barcode**.
+        *   `scanner_listener.py` captures it, sends it to the Flask API.
+        *   Flask API processes it:
+            *   If valid & eligible: LCD shows "OK: Scan Booklet". `scan_status.json` updated to expect "booklet" and stores verified student.
+            *   If invalid/ineligible: LCD shows error/warning. `scan_status.json` might be updated to show student was checked but not proceed, or remain expecting "student".
+    *   If student was eligible, the person at the Pi scans a **Booklet Code barcode**.
+        *   `scanner_listener.py` captures it, sends it to Flask API.
+        *   Flask API processes it:
+            *   If valid: Scan recorded in DB. LCD shows success. `scan_status.json` updated to expect "student" again for next scan.
+            *   If duplicate/error: LCD shows error/warning.
+
+3.  **Monitoring (Remote Web Browser):**
+    *   Admin can navigate to the `/scan` page (now a status display page) to see the current active exam and expected input type. This page includes a refresh button.
+    *   Admin can view the "Scan Records" page to see a list of all successful scans.
+
+4.  **Ending Scanning Session (Admin):**
+    *   Admin clicks "Stop Auth" for the active exam on the "Manage Exams" page.
+        *   Flask app updates `scan_status.json` (no active exam).
+        *   LCD reverts to showing IP address.
+        *   `scanner_listener.py` sees no active exam and idles.
+
+## Original Usage (Manual/Browser-Based Scanning - Now Superseded by Headless Mode)
+The previous method of scanning involved using the web browser's input fields on the `/scan` page. With the introduction of the headless `scanner_listener.py`, this direct browser input method for scanning is no longer the primary mechanism for Raspberry Pi deployments. The `/scan` page now serves as a status display.
+
+## Future Considerations/Improvements
+*   **Flask-Migrate:** Implement database migrations for robust schema updates.
+*   **Real-time Web UI for `/scan`:** Use WebSockets or Server-Sent Events to update the `/scan` status page instantly when scans occur, instead of relying on refresh.
+*   **More Robust Scanner Discovery in `scanner_listener.py`:** Improve heuristics or allow selection if multiple devices are found (e.g., via a config file).
+*   **Configuration File:** Move settings like `SCANNER_DEVICE_PATH`, API endpoint, log paths, etc., from script constants to a dedicated configuration file (e.g., `config_listener.ini`).
+*   **Advanced Scan Record Viewing/Reporting:** Enhance the "Scan Records" page with filtering, searching, and export options.
+*   **Comprehensive Testing:** Expand unit and integration tests, especially for the new listener script and API interaction.
+
+*(Old "Raspberry Pi Deployment with I2C LCD" subsections have been removed or integrated into the new "Headless Raspberry Pi Scanning Setup" section.)*
 ```


### PR DESCRIPTION
- Add `scanner_listener.py` to read from USB scanner using `evdev`.
- Introduce `scan_status.json` for state management between Flask app and listener.
- Create internal API endpoint `/api/v1/internal_scan` in Flask to process scans from listener.
- Modify admin routes to update `scan_status.json` when starting/stopping exam authentication.
- Revise `/scan` web UI to be a status display page for headless operation.
- Update LCD control to reflect states driven by direct scanner input.
- Add `evdev` and `requests` to requirements.
- Extensively update README.md with setup and operational details for the new headless architecture, including systemd service examples and udev rules.