### PR TITLE
feat: Enhance Scan Records and UI notifications

### DIFF
--- a/Booklet_Scan/app/templates/admin/scan_records_list.html
+++ b/Booklet_Scan/app/templates/admin/scan_records_list.html
@@ -22,31 +22,39 @@
                             <th>Student ID</th>
                             <th>Exam Name</th>
                             <th>Booklet Code</th>
+                            <th>Total Booklets by Student</th>
                             <th>Timestamp (UTC)</th>
                             <th>Timestamp (Local)</th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for record in scan_records.items %}
+                        {% for record in scan_records.items %} {# record is now a ScanRecord object #}
                         <tr>
                             <td>{{ (scan_records.page - 1) * scan_records.per_page + loop.index }}</td> {# Global record number #}
-                            <td>{{ record.student_name }}</td>
-                            <td>{{ record.student_identifier }}</td>
-                            <td>{{ record.exam_name }}</td>
+                            <td>{{ record.student.name if record.student else 'N/A' }}</td>
+                            <td>{{ record.student.student_id if record.student else 'N/A' }}</td>
+                            <td>{{ record.exam.name if record.exam else 'N/A' }}</td>
                             <td>{{ record.booklet_code }}</td>
+                            <td>
+                                {% if record.student %}
+                                    {{ record.student.scans.count() }}
+                                {% else %}
+                                    N/A
+                                {% endif %}
+                            </td>
                             <td>{{ record.timestamp.strftime('%Y-%m-%d %H:%M:%S') }}</td>
                             {# Convert UTC to local time using JavaScript for client-side display #}
                             <td data-utc-timestamp="{{ record.timestamp.isoformat() }}">
                                 <script>
                                     (function() {
-                                        var elements = document.querySelectorAll('td[data-utc-timestamp="{{ record.timestamp.isoformat() }}"]');
-                                        elements.forEach(function(element) {
-                                            if (!element.getAttribute('data-converted')) {
-                                                var utcDate = new Date(element.getAttribute('data-utc-timestamp'));
-                                                element.textContent = utcDate.toLocaleString();
-                                                element.setAttribute('data-converted', 'true');
-                                            }
-                                        });
+                                        // Ensure script targets unique element for each record
+                                        var currentScript = document.currentScript;
+                                        var parentTd = currentScript.closest('td[data-utc-timestamp]');
+                                        if (parentTd && !parentTd.getAttribute('data-converted')) {
+                                            var utcDate = new Date(parentTd.getAttribute('data-utc-timestamp'));
+                                            parentTd.textContent = utcDate.toLocaleString();
+                                            parentTd.setAttribute('data-converted', 'true');
+                                        }
                                     })();
                                 </script>
                             </td>

--- a/Booklet_Scan/app/templates/base.html
+++ b/Booklet_Scan/app/templates/base.html
@@ -65,8 +65,22 @@
       </div>
     </nav>
 
-    {# Main content block for child templates. Flash messages are handled within child templates like scan_interface.html or admin pages #}
     <div class="container mt-3">
+      {# Flash messages section #}
+      {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+          {% for category, message in messages %}
+            <div class="alert alert-{{ category if category != 'message' else 'info' }} alert-dismissible fade show" role="alert">
+              {{ message }}
+              <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+          {% endfor %}
+        {% endif %}
+      {% endwith %}
+      {# End Flash messages section #}
+
       {% block app_content %}{% endblock %}
       {% block content %}{% endblock %} {# Kept for compatibility if any old templates use it directly, prefer app_content #}
     </div>
@@ -74,5 +88,19 @@
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.2/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+      $(document).ready(function() {
+        // Auto-dismiss alerts after 1.5 seconds
+        // Exclude alerts with the 'no-auto-dismiss' class if you want some to persist
+        $('.alert').not('.no-auto-dismiss').each(function() {
+          var alert = $(this);
+          setTimeout(function() {
+            alert.fadeOut('slow', function() {
+              $(this).remove(); // Removes the element from DOM after fade out
+            });
+          }, 1500); // 1500 milliseconds = 1.5 seconds
+        });
+      });
+    </script>
   </body>
 </html>


### PR DESCRIPTION
- Display total booklets used by student in Scan Records list:
  - Modified `list_scan_records` route to fetch ScanRecord objects with related student and exam data eager-loaded.
  - Updated `scan_records_list.html` template to add a new column for "Total Booklets by Student" and display the count using `student.scans.count()`.

- Implement auto-clear for flash messages:
  - Added a standard flash message rendering section to `base.html`.
  - Included a JavaScript snippet in `base.html` to automatically fade out and remove flash messages (Bootstrap alerts) after 1.5 seconds.
  - Allows for manual dismissal and opting out of auto-dismissal with a specific class.